### PR TITLE
Adopt uv, ruff, mypy and pyright

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,8 +1,0 @@
-[flake8]
-max-line-length = 88
-extend-ignore = E203
-exclude =
-    .git,
-    .nox,
-    .venv,
-    __pycache__,

--- a/.github/workflows/nox.yaml
+++ b/.github/workflows/nox.yaml
@@ -24,15 +24,34 @@ jobs:
     steps:
       - run: sudo apt-get update && sudo apt-get --yes install meson
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      - uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6
         with: { python-version: "3.13" }
-        id: setup
-      - run: pipx run "--python=${{ steps.setup.outputs.python-path }}" nox
+      - run: ./noxfile.py
       - run: git diff --exit-code dist/SHA256SUMS
-      - run: >-
-          pipx run "--python=${{ steps.setup.outputs.python-path }}"
-          nox --session=github_output >> "$GITHUB_OUTPUT"
-        id: version
+      - id: version
+        shell: python
+        run: |
+          #!/usr/bin/env python3
+          """Write the version number to GITHUB_OUTPUT."""
+
+          from os import environ
+          from pathlib import Path
+
+          START = '__version__ = "'
+          END = '"'
+          OUTPUT = Path(environ.get("GITHUB_OUTPUT", "github_output.txt"))
+
+
+          for line in Path("reproducibly.py").read_text().splitlines():
+              if line.startswith(START) and line.endswith(END):
+                  break
+          else:
+              msg = "Line not found."
+              raise ValueError(msg)
+
+          msg = "version=" + line.removeprefix(START).removesuffix(END) + "\n"
+          OUTPUT.write_text(msg)
+
       - name: Upload dist/ for the publish job and to debug unexpected changes
         # yamllint disable-line rule:line-length
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.github/workflows/nox.yaml
+++ b/.github/workflows/nox.yaml
@@ -34,10 +34,12 @@ jobs:
           nox --session=github_output >> "$GITHUB_OUTPUT"
         id: version
       - name: Upload dist/ for the publish job and to debug unexpected changes
+        # yamllint disable-line rule:line-length
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with: { name: dist, path: dist }
         if: always()
       - name: Upload wheelhouse/ to debug unexpected changes
+        # yamllint disable-line rule:line-length
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with: { name: wheelhouse, path: wheelhouse }
         if: always()
@@ -61,6 +63,7 @@ jobs:
         if: >-
           ${{ !( github.ref == 'refs/heads/main'
           || contains(github.event.inputs.repository-url, 'test')) }}
+        # yamllint disable-line rule:line-length
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with: { name: dist, path: dist }
       - run: cd dist && sha256sum -c SHA256SUMS && rm SHA256SUMS

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -17,6 +17,16 @@
         "    \"(?<depName>.+?)==(?<currentValue>.+?)\","
       ],
       "datasourceTemplate": "pypi"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "noxfile.py"
+      ],
+      "matchStrings": [
+        "\\\"(?<depName>.+?)@(?<currentValue>.+?)\\\""
+      ],
+      "datasourceTemplate": "npm"
     }
   ],
   "packageRules": [
@@ -24,6 +34,13 @@
       "description": "Automerge upgrades to GitHub Actions",
       "matchManagers": [
         "github-actions"
+      ],
+      "automerge": true
+    },
+    {
+      "description": "Automerge upgrades to pyright",
+      "matchDepNames": [
+        "pyright"
       ],
       "automerge": true
     }

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,16 @@
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+  comments-indentation: false
+  comments:
+    min-spaces-from-content: 1
+  document-start: disable
+  octal-values:
+    forbid-implicit-octal: true
+    forbid-explicit-octal: true
+#
+# SPDX-FileCopyrightText: 2025 Keith Maxwell <keith.maxwell@gmail.com>
+# SPDX-License-Identifier: CC0-1.0
+# vim: set ft=yaml :

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ cog.out("\n```\n" + RESULT.stdout + "```\n\n")
 ```
 usage: reproducibly.py [-h] [--version] input [input ...] output
 
-Reproducibly build Python packages
+Reproducibly build Python packages.
 
 features:
 

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -7,7 +7,6 @@ SPDX-PackageDownloadLocation = "https://github.com/maxwell-k/reproducibly"
 path = [
   ".coveragerc",
   ".en.utf-8.add",
-  ".flake8",
   ".gitignore",
   "dist/SHA256SUMS",
   "dprint.json",

--- a/cleanse_sdist.py
+++ b/cleanse_sdist.py
@@ -1,4 +1,4 @@
-"""Cleanse a source distributions
+"""Cleanse a source distributions.
 
 Originally based on
 https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/python-modules/setuptools/default.nix#L36
@@ -7,13 +7,14 @@ https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/python-modules/set
 # cleanse_sdist.py
 # Copyright 2023 Keith Maxwell
 # SPDX-License-Identifier: MPL-2.0
-from argparse import ArgumentParser
+from argparse import ArgumentParser, Namespace
 from pathlib import Path
 
 from reproducibly import cleanse_sdist, EARLIEST
 
 
-def parse_args(args: list[str] | None):
+def parse_args(args: list[str] | None) -> Namespace:
+    """Parse command line arguments for cleanse_sdist."""
     parser = ArgumentParser(description="Cleanse metadata from source distributions")
     parser.add_argument(
         "source_distribution",
@@ -30,7 +31,7 @@ def parse_args(args: list[str] | None):
 
 
 def main(arguments: list[str] | None = None) -> int:
-    """Call cleanse_sdist once for each input"""
+    """Call cleanse_sdist once for each input."""
     parsed = parse_args(arguments)
     returncode = 0
     # try all source distributions before exiting with an error

--- a/cleanse_sdist_test.py
+++ b/cleanse_sdist_test.py
@@ -1,3 +1,5 @@
+"""Tests for cleanse_sdist.py."""
+
 # cleanse_sdist_test.py
 # Copyright 2023 Keith Maxwell
 # SPDX-License-Identifier: MPL-2.0
@@ -10,7 +12,10 @@ from reproducibly_test import SimpleFixtureMixin
 
 
 class TestMainWithFixture(SimpleFixtureMixin, unittest.TestCase):
-    def test_main_using_fixture(self):
+    """Tests for main from cleanse_sdist.py."""
+
+    def test_main_using_fixture(self) -> None:
+        """Check that the file mode for all members is set to 0o755."""
         self.sdist.rename(f"{self.sdist}.orig")
         with (
             tarfile.open(f"{self.sdist}.orig", "r:gz") as source,
@@ -23,13 +28,16 @@ class TestMainWithFixture(SimpleFixtureMixin, unittest.TestCase):
         returncode = main([str(self.sdist)])
 
         with tarfile.open(self.sdist) as tar:
-            modes = {"0o%o" % tarinfo.mode for tarinfo in tar.getmembers()}
+            modes = {f"0o{tarinfo.mode:o}" for tarinfo in tar.getmembers()}
         self.assertEqual(returncode, 0)
         self.assertEqual(modes, {"0o755"})
 
 
 class TestParseArgs(unittest.TestCase):
-    def test_missing_file(self):
+    """Test for parse_args from cleanse_sdist.py."""
+
+    def test_missing_file(self) -> None:
+        """Check an exception is raised if args is a file that does not exist."""
         with patch("builtins.print") as mock, self.assertRaises(SystemExit) as cm:
             parse_args(["missing_file.tar.gz"])
         self.assertEqual(cm.exception.code, 1)

--- a/dist/SHA256SUMS
+++ b/dist/SHA256SUMS
@@ -1,2 +1,2 @@
-113c50cfefda7cdd963b6fc16fc4e9206a86fdad8a691a8ecea9c884d370416e  reproducibly-0.0.15-py3-none-any.whl
-5d0f7042f63194cfb7738a12b2fdc16a0490a70000cf0a5f8f5ab8f1bab5779c  reproducibly-0.0.15.tar.gz
+3a44efe79f76af3c838327e2ba0754dfd8af9f4cf71dcba8a1705d6efd1488cf  reproducibly-0.0.15-py3-none-any.whl
+e97a5acd9289c3a93321730e3e25624fa55add17ef2716a768976b6dd5c9d9d0  reproducibly-0.0.15.tar.gz

--- a/dist/SHA256SUMS
+++ b/dist/SHA256SUMS
@@ -1,2 +1,2 @@
-3a44efe79f76af3c838327e2ba0754dfd8af9f4cf71dcba8a1705d6efd1488cf  reproducibly-0.0.15-py3-none-any.whl
-e97a5acd9289c3a93321730e3e25624fa55add17ef2716a768976b6dd5c9d9d0  reproducibly-0.0.15.tar.gz
+e7650243b2042bf15344ff72912bf696ca665ad4ab0d8b33e36f8800b647ae8e  reproducibly-0.0.16-py3-none-any.whl
+32612f3c0a43bbe9850bfba6b9a85cf94d1914d1215a179e2a5134c634c74284  reproducibly-0.0.16.tar.gz

--- a/fixtures/extension/setup.py
+++ b/fixtures/extension/setup.py
@@ -1,3 +1,7 @@
+"""Test fixture."""
+
+# ruff: noqa: INP001
+
 # SPDX-FileCopyrightText: 2024 Keith Maxwell
 #
 # SPDX-License-Identifier: CC0-1.0

--- a/fixtures/extension/src/extension/__init__.py
+++ b/fixtures/extension/src/extension/__init__.py
@@ -1,0 +1,4 @@
+"""Print hello world."""
+
+# SPDX-FileCopyrightText: 2025 Keith Maxwell
+# SPDX-License-Identifier: MPL-2.0

--- a/fixtures/extension/src/extension/__main__.py
+++ b/fixtures/extension/src/extension/__main__.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2024 Keith Maxwell
 #
 # SPDX-License-Identifier: MPL-2.0
+"""Print hello world."""
 
 import ctypes
 

--- a/fixtures/simple/pyproject.toml
+++ b/fixtures/simple/pyproject.toml
@@ -4,9 +4,8 @@ version = "0.0.1"
 description = "An example package"
 readme = "README.md"
 authors = [{ name = "Keith Maxwell", email = "keith.maxwell@gmail.com" }]
-license = { text = "MPL 2.0" }
+license = "MPL-2.0"
 classifiers = [
-  "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
   "Development Status :: 3 - Alpha",
   "Intended Audience :: Developers",
   "Programming Language :: Python :: 3.13",

--- a/fixtures/simple/src/simple.py
+++ b/fixtures/simple/src/simple.py
@@ -1,5 +1,8 @@
 # fixtures/simple/src/simple.py
+# ruff: noqa: INP001
 # Copyright 2023 Keith Maxwell
 # SPDX-License-Identifier: MPL-2.0
+"""Print hello world."""
+
 if __name__ == "__main__":
     print("hello world")

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env -S uv run
+"""Build tooling for the reproducibly project."""
 # noxfile.py
 # Copyright 2023 Keith Maxwell
 # SPDX-License-Identifier: MPL-2.0
@@ -15,10 +16,13 @@ from shutil import rmtree, which
 from typing import Literal
 
 import nox
+from nox.sessions import Session
 from packaging.requirements import Requirement  # see below
 
 # nox depends on packaging so it is safe to import as well
 # https://github.com/wntrblm/nox/blob/main/pyproject.toml#L46
+
+nox.options.default_venv_backend = "uv"
 
 DEVELOPMENT = [
     "black",
@@ -30,13 +34,12 @@ DEVELOPMENT = [
     "reuse",
     "usort",
 ]
-PRIMARY = "3.13"
-VIRTUAL_ENVIRONMENT = ".venv"
-CWD = Path(".").absolute()
+VIRTUAL_ENV = ".venv"
+_CWD = Path().absolute()
 OUTPUT = Path("dist")
-PYTHON = CWD / VIRTUAL_ENVIRONMENT / "bin" / "python"
-SDISTS = CWD / "sdists"
-WHEELS = CWD / "wheelhouse"
+PYTHON = _CWD / VIRTUAL_ENV / "bin" / "python"
+SDISTS = _CWD / "sdists"
+WHEELS = _CWD / "wheelhouse"
 SCRIPT = Path("reproducibly.py")
 
 # https://peps.python.org/pep-0723/#reference-implementation
@@ -88,16 +91,18 @@ nox.options.sessions = [
 ]
 
 
-def _cog(session, action: Literal["-r"] | Literal["--check"]) -> None:
-    if not Path(VIRTUAL_ENVIRONMENT).is_dir():
+def _cog(session: Session, action: Literal["-r", "--check"]) -> None:
+    if not Path(VIRTUAL_ENV).is_dir():
         _setup_venv(session, ["cogapp"])
     session.run(".venv/bin/python", "-m", "cogapp", action, SCRIPT, "README.md")
 
 
-def _setup_venv(session, additional: list[str]) -> None:
-    rmtree(VIRTUAL_ENVIRONMENT, ignore_errors=True)
-    session.run(f"python{PRIMARY}", "-m", "venv", "--upgrade-deps", VIRTUAL_ENVIRONMENT)
-    session.run(PYTHON, "-m", "pip", "install", *_read_dependency_block(), *additional)
+def _setup_venv(session: Session, additional: list[str]) -> None:
+    session.install("uv")
+    required = nox.project.load_toml("pyproject.toml")["project"]["requires-python"]
+    session.run("uv", "venv", "--python", required, VIRTUAL_ENV)
+    env = {"VIRTUAL_ENV": VIRTUAL_ENV}
+    session.run("uv", "pip", "install", "--editable", ".[test]", *additional, env=env)
 
 
 def _sha256(path: Path) -> str:
@@ -106,25 +111,25 @@ def _sha256(path: Path) -> str:
 
 
 def read(script: str) -> dict | None:
-    """https://peps.python.org/pep-0723/#reference-implementation"""
+    """See https://peps.python.org/pep-0723/#reference-implementation."""
     name = "script"
     matches = list(
-        filter(lambda m: m.group("type") == name, re.finditer(REGEX, script))
+        filter(lambda m: m.group("type") == name, re.finditer(REGEX, script)),
     )
     if len(matches) > 1:
-        raise ValueError(f"Multiple {name} blocks found")
-    elif len(matches) == 1:
+        msg = f"Multiple {name} blocks found"
+        raise ValueError(msg)
+    if len(matches) == 1:
         content = "".join(
             line[2:] if line.startswith("# ") else line[1:]
             for line in matches[0].group("content").splitlines(keepends=True)
         )
         return tomllib.loads(content)
-    else:
-        return None
+    return None
 
 
 def _read_dependency_block(script: Path = SCRIPT) -> list[str]:
-    """Read script dependencies"""
+    """Read script dependencies."""
     metadata = read(Path(script).read_text())
     if metadata is None or "dependencies" not in metadata:
         print(f"Invalid metadata in {script}")
@@ -132,31 +137,31 @@ def _read_dependency_block(script: Path = SCRIPT) -> list[str]:
     return metadata["dependencies"]
 
 
-@nox.session(python=PRIMARY)
-def preamble(session) -> None:
-    """Display the Python and Nox versions"""
+@nox.session()
+def preamble(session: Session) -> None:
+    """Display the Python and Nox versions."""
     session.run("python", "--version")
     session.log("nox --version (simulated)")
     print(version("nox"))
 
 
 @nox.session(python=False)
-def generated(session) -> None:
-    """Check that the files have been generated"""
+def generated(session: Session) -> None:
+    """Check that the files have been generated."""
     _cog(session, "--check")
 
 
-@nox.session(python=PRIMARY)
-def static(session) -> None:
-    """Run static analysis: usort, black and flake8"""
+@nox.session()
+def static(session: Session) -> None:
+    """Run static analysis."""
+    session.install("ruff")
+    session.run("ruff", "check")
+
     session.install("usort")
     session.run("usort", "check", ".")
 
     session.install("black")
     session.run("black", "--check", ".")
-
-    session.install("flake8")
-    session.run("flake8")
 
     session.install("codespell")
     session.run("codespell")
@@ -165,18 +170,18 @@ def static(session) -> None:
     session.run("yamllint", ".github")
 
 
-@nox.session(python=PRIMARY)
-def repository(session) -> None:
-    """Run automated tests based upon the contents of this repository"""
+@nox.session()
+def repository(session: Session) -> None:
+    """Run automated tests and ensure 100% coverage."""
     session.install("coverage", *_read_dependency_block())
     session.run("python", "-m", "coverage", "run")
     session.run("python", "-m", "coverage", "html")
     session.run("python", "-m", "coverage", "report", "--fail-under=100")
 
 
-@nox.session(python=PRIMARY)
-def pypi(session) -> None:
-    """Check hashes of wheels built from downloaded sdists from pypi"""
+@nox.session()
+def pypi(session: Session) -> None:
+    """Check hashes of wheels built from downloaded sdists from pypi."""
     rmtree(SDISTS, ignore_errors=True)
     session.install("--upgrade", "pip")
     # beancount uses meson and meson-python as a build backend. `pip download`
@@ -215,7 +220,7 @@ def pypi(session) -> None:
         SCRIPT,
         *SDISTS.iterdir(),
         WHEELS,
-        env=dict(CIBW_BEFORE_ALL=CIBW_BEFORE_ALL),
+        env={"CIBW_BEFORE_ALL": CIBW_BEFORE_ALL},
     )
 
     # List each file for a specifier
@@ -227,29 +232,33 @@ def pypi(session) -> None:
 
     sdist_digests = list(map(_sha256, sdists))
     wheel_digests = list(map(_sha256, wheels))
-    assert len(sdists) == len(SPECIFIERS), f"Expected {len(SPECIFIERS)} sdists"
-    assert len(wheels) == len(SPECIFIERS), f"Expected {len(SPECIFIERS)} wheels"
-    assert (
-        sdist_digests == SDIST_DIGESTS
-    ), f"Sdist digests {sdist_digests} do not match expected {SDIST_DIGESTS}"
-    assert (
-        wheel_digests == WHEEL_DIGESTS
-    ), f"Wheel digests {wheel_digests} do not match expected {WHEEL_DIGESTS}"
+    if len(sdists) != len(SPECIFIERS):
+        msg = f"Expected {len(SPECIFIERS)} sdists"
+        raise ValueError(msg)
+    if len(wheels) != len(SPECIFIERS):
+        msg = f"Expected {len(SPECIFIERS)} wheels"
+        raise ValueError(msg)
+    if sdist_digests != SDIST_DIGESTS:
+        msg = f"Sdist digests {sdist_digests} do not match expected {SDIST_DIGESTS}"
+        raise ValueError(msg)
+    if wheel_digests != WHEEL_DIGESTS:
+        msg = f"Wheel digests {wheel_digests} do not match expected {WHEEL_DIGESTS}"
+        raise ValueError(msg)
 
 
-@nox.session(python=PRIMARY)
-def reuse(session) -> None:
-    """Run reuse lint outside of CI"""
+@nox.session()
+def reuse(session: Session) -> None:
+    """Run reuse lint outside of CI."""
     session.install("reuse")
     session.run("python", "-m", "reuse", "lint")
 
 
-@nox.session(python=PRIMARY)
-def distributions(session) -> None:
-    """Produce a source and binary distribution"""
+@nox.session()
+def distributions(session: Session) -> None:
+    """Produce a source and binary distribution."""
     session.install(*_read_dependency_block())
     rmtree(OUTPUT, ignore_errors=True)
-    session.run("python", SCRIPT, ".", OUTPUT, env=dict(SOURCE_DATE_EPOCH="315532800"))
+    session.run("python", SCRIPT, ".", OUTPUT, env={"SOURCE_DATE_EPOCH": "315532800"})
     sdist = next(OUTPUT.iterdir())
     session.run("python", SCRIPT, sdist, OUTPUT)
     files = sorted(OUTPUT.iterdir())
@@ -258,31 +267,23 @@ def distributions(session) -> None:
     OUTPUT.joinpath("SHA256SUMS").write_text(text)
 
 
-@nox.session(python=PRIMARY)
-def check(session) -> None:
-    """Check the built distributions with twine"""
+@nox.session()
+def check(session: Session) -> None:
+    """Check the built distributions with twine."""
     session.install("twine")
     session.run("twine", "check", "--strict", *OUTPUT.glob("*.*"))
 
 
 @nox.session(python=False)
-def dev(session) -> None:
-    """Set up a development environment (virtual environment)"""
+def dev(session: Session) -> None:
+    """Set up a development environment (virtual environment)."""
     _setup_venv(session, DEVELOPMENT)
 
 
 @nox.session(python=False)
-def generate(session) -> None:
-    """Run cog on SCRIPT and README.md"""
+def generate(session: Session) -> None:
+    """Run cog on SCRIPT and README.md."""
     _cog(session, "-r")
-
-
-@nox.session(python=PRIMARY)
-def github_output(session) -> None:
-    """Display outputs for CI integration"""
-    session.install("coverage", *_read_dependency_block())
-    version = session.run("python", SCRIPT, "--version", silent=True).strip()
-    print(f"version={version}")  # version= adds quotes
 
 
 if __name__ == "__main__":

--- a/noxfile.py
+++ b/noxfile.py
@@ -26,10 +26,12 @@ DEVELOPMENT = [
     "codespell",
     "cogapp",
     "coverage",
+    "mypy",
     "nox",
     "reuse",
     "ruff",
     "usort",
+    "types-setuptools",  # for fixtures
     "yamllint",
 ]
 VIRTUAL_ENV = ".venv"
@@ -163,6 +165,7 @@ def static(session: Session) -> None:
     run("ruff check .")
     run("codespell_lib")
     run("yamllint --strict .github")
+    run("mypy .")
 
 
 @nox.session()

--- a/noxfile.py
+++ b/noxfile.py
@@ -158,7 +158,7 @@ def static(session: Session) -> None:
         session.run(PYTHON, "-m", *cmd.split(), external=True)
 
     run("reuse lint")
-    run("usort check src noxfile.py")
+    run("usort check .")
     run("black --check .")
     run("ruff check .")
     run("codespell_lib")

--- a/noxfile.py
+++ b/noxfile.py
@@ -152,20 +152,28 @@ def generated(session: Session) -> None:
         session.error(msg)
 
 
-@nox.session(requires=["dev"])
+@nox.session(venv_backend="none", requires=["dev"])
 def static(session: Session) -> None:
-    """Run static analysis."""
+    """Run static analysis tools."""
+    session.run(
+        "npm",
+        "exec",
+        "pyright@1.1.403",
+        "--yes",
+        "--",
+        f"--pythonpath={PYTHON}",
+    )
 
     def run(cmd: str) -> None:
-        session.run(PYTHON, "-m", *cmd.split(), external=True)
+        session.run(PYTHON, "-m", *cmd.split())
 
     run("reuse lint")
     run("usort check .")
     run("black --check .")
     run("ruff check .")
     run("codespell_lib")
-    run("yamllint --strict .github")
     run("mypy .")
+    run("yamllint --strict .github")
 
 
 @nox.session()

--- a/noxfile.py
+++ b/noxfile.py
@@ -161,6 +161,9 @@ def static(session) -> None:
     session.install("codespell")
     session.run("codespell")
 
+    session.install("yamllint")
+    session.run("yamllint", ".github")
+
 
 @nox.session(python=PRIMARY)
 def repository(session) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ readme = "README.md"
 requires-python = ">=3.13"
 classifiers = [
   "Programming Language :: Python :: 3",
-  "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
 ]
 dependencies = [
   "build==1.2.2.post1",
@@ -23,6 +22,7 @@ dependencies = [
   "packaging==25.0",
   "pyproject-hooks==1.2.0",
 ]
+licence = "MPL-2.0"
 
 [project.urls]
 Homepage = "https://github.com/maxwell-k/reproducibly/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
   "build==1.2.2.post1",
   "cibuildwheel==3.0.1",
   "packaging==25.0",
-  "pyproject_hooks==1.2.0",
+  "pyproject-hooks==1.2.0",
 ]
 
 [project.urls]
@@ -33,3 +33,16 @@ reproducibly = "reproducibly:main"
 
 [tool.codespell]
 skip = './htmlcov'
+
+[tool.ruff.lint]
+select = ["ALL"]
+ignore = [
+  "D203", # incompatible with D211
+  "D213", # incompatible with D212
+  "I", # prefer usort to ruff isort implementation
+  "PT", # prefer unittest style
+  "S310", # the rule errors on the "use instead" code from `ruff rule S310`
+  "S602", # assume arguments to subprocess.run are validated
+  "S603", # assume trusted input  to subprocess.run
+  "T201", # print is used for output in command line scripts
+]

--- a/reproducibly.py
+++ b/reproducibly.py
@@ -27,10 +27,9 @@ from subprocess import CalledProcessError, run
 from sys import version_info
 from tarfile import TarFile, TarInfo
 from tempfile import TemporaryDirectory
+from types import TracebackType
 from typing import cast, Literal, TypedDict
 from zipfile import ZIP_DEFLATED, ZipFile, ZipInfo
-from types import TracebackType
-
 
 from build import ProjectBuilder
 from build.env import DefaultIsolatedEnv

--- a/reproducibly.py
+++ b/reproducibly.py
@@ -57,7 +57,7 @@ from pyproject_hooks import default_subprocess_runner
 EARLIEST = datetime(1980, 1, 1, 0, 0, 0, tzinfo=UTC).timestamp()  # 315532800.0
 
 
-__version__ = "0.0.15"
+__version__ = "0.0.16"
 
 
 def _build(

--- a/reproducibly_test.py
+++ b/reproducibly_test.py
@@ -1,19 +1,26 @@
+"""Tests for reproducibly.py."""
+
 # SPDX-FileCopyrightText: 2024 Keith Maxwell <keith.maxwell@gmail.com>
 #
 # SPDX-License-Identifier: MPL-2.0
+#
+# ruff: noqa: D102 require docstrings for methods
+
 import gzip
 import tarfile
 import unittest
 from contextlib import chdir
-from datetime import datetime
+from datetime import datetime, UTC
 from operator import attrgetter
 from os import utime
 from pathlib import Path
+from random import sample, seed
 from shutil import rmtree
 from stat import filemode
-from subprocess import run
+from subprocess import CompletedProcess, run
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 from time import mktime
+from typing import Any, Literal
 from unittest.mock import ANY, patch
 from zipfile import ZIP_DEFLATED, ZipFile, ZipInfo
 
@@ -25,6 +32,7 @@ from reproducibly import (
     breadth_first_key,
     Builder,
     cleanse_sdist,
+    EARLIEST,
     fix_zip_members,
     key,
     latest_modification_time,
@@ -35,7 +43,9 @@ from reproducibly import (
 
 
 class TestBuilder(unittest.TestCase):
-    def test_build(self):
+    """Test the Builder class."""
+
+    def test_build(self) -> None:
         with TemporaryDirectory() as tmpdir:
             path = Path(tmpdir)
             file = path / "1.py"
@@ -46,7 +56,7 @@ class TestBuilder(unittest.TestCase):
 
             self.assertEqual(Builder.which(archive), Builder.build)
 
-    def test_cibuildwheel(self):
+    def test_cibuildwheel(self) -> None:
         with TemporaryDirectory() as tmpdir:
             path = Path(tmpdir)
             file = path / "1.c"
@@ -59,28 +69,34 @@ class TestBuilder(unittest.TestCase):
 
 
 class TestBreadthFirstKey(unittest.TestCase):
-    def test_files_before_directories(self):
+    """Test the breadth_first_key function."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        seed(18)
+
+    def test_files_before_directories(self) -> None:
         data = [
             "2.py",
             "1/?.py",
         ]
-        self.assertEqual(sorted(data[::-1], key=breadth_first_key), data)
+        self.assertEqual(sorted(sample(data, len(data)), key=breadth_first_key), data)
 
-    def test_key_files_in_order(self):
+    def test_key_files_in_order(self) -> None:
         data = [
             "1.py",
             "2.py",
         ]
-        self.assertEqual(sorted(data[::-1], key=breadth_first_key), data)
+        self.assertEqual(sorted(sample(data, len(data)), key=breadth_first_key), data)
 
-    def test_key_directories_in_order(self):
+    def test_key_directories_in_order(self) -> None:
         data = [
             "1/?.py",
             "2/?.py",
         ]
-        self.assertEqual(sorted(data[::-1], key=breadth_first_key), data)
+        self.assertEqual(sorted(sample(data, len(data)), key=breadth_first_key), data)
 
-    def test_key_arbitrary_depth(self):
+    def test_key_arbitrary_depth(self) -> None:
         data = [
             "4.py",
             "1/2.py",
@@ -88,12 +104,14 @@ class TestBreadthFirstKey(unittest.TestCase):
             "2/?/?.py",
             "3/?.py",
         ]
-        self.assertEqual(sorted(data[::-1], key=breadth_first_key), data)
+        self.assertEqual(sorted(sample(data, len(data)), key=breadth_first_key), data)
 
 
 class TestKey(unittest.TestCase):
+    """Test the key function."""
+
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
         cls._STRINGS = (
             "a/__init__.py",
             "a/z.py",
@@ -107,29 +125,31 @@ class TestKey(unittest.TestCase):
         )
         cls.LINES = [i.encode() + b",sha256=X,1234\n" for i in cls._STRINGS]
         cls.ZIPINFOS = [ZipInfo(i) for i in cls._STRINGS]
-        _UNSORTED = [2, 3, 0, 1, 4, 7, 6, 5, 8]
-        cls.UNSORTED_LINES = [cls.LINES[i] for i in _UNSORTED]
-        cls.UNSORTED_ZIPINFOS = [cls.ZIPINFOS[i] for i in _UNSORTED]
+        _unsorted = [2, 3, 0, 1, 4, 7, 6, 5, 8]
+        cls.UNSORTED_LINES = [cls.LINES[i] for i in _unsorted]
+        cls.UNSORTED_ZIPINFOS = [cls.ZIPINFOS[i] for i in _unsorted]
 
-    def test_is_idempotent(self):
+    def test_is_idempotent(self) -> None:
         result = sorted(self.LINES, key=key)
         self.assertEqual(self.LINES, result)
 
-    def test_returns_expected_results(self):
+    def test_returns_expected_results(self) -> None:
         result = sorted(self.UNSORTED_LINES, key=key)
         self.assertEqual(self.LINES, result)
 
-    def test_is_idempotent_for_zipinfos(self):
+    def test_is_idempotent_for_zipinfos(self) -> None:
         result = sorted(self.ZIPINFOS, key=key)
         self.assertEqual(self.ZIPINFOS, result)
 
-    def test_returns_expected_results_for_zipinfo(self):
+    def test_returns_expected_results_for_zipinfo(self) -> None:
         result = sorted(self.UNSORTED_ZIPINFOS, key=key)
         self.assertEqual(self.ZIPINFOS, result)
 
 
 class TestLatestModificationTime(unittest.TestCase):
-    def test_basic(self):
+    """Test the latest_modification_time function."""
+
+    def test_basic(self) -> None:
         with TemporaryDirectory() as tmpdir:
             path = Path(tmpdir)
             one = path / "1.txt"
@@ -151,7 +171,9 @@ class TestLatestModificationTime(unittest.TestCase):
 
 
 class TestFixZipMembers(unittest.TestCase):
-    def test_basic(self):
+    """Test the fix_zip_members function."""
+
+    def test_basic(self) -> None:
         with TemporaryDirectory() as tmpdir:
             path = Path(tmpdir)
             one = path / "1.txt"
@@ -174,23 +196,24 @@ class TestFixZipMembers(unittest.TestCase):
 
 
 class TestMain(unittest.TestCase):
+    """Test the main function."""
 
     @classmethod
-    def setUpClass(cls):
-        DATE = "2024-01-01T00:00:01"
-        cls.DATE = datetime.fromisoformat(DATE)
+    def setUpClass(cls) -> None:
+        date = "2024-01-01T00:00:01"
+        cls.date = datetime.fromisoformat(date).replace(tzinfo=UTC)
         cls.simple_repository = "fixtures/simple"
         cls.extension_repository = "fixtures/extension"
         cls._clean()
 
         for path in (cls.simple_repository, cls.extension_repository):
 
-            def execute(*args: str):
+            def execute(*args: str, path: str = path) -> None:
                 run(
                     ("git", "-C", path, *args),
                     capture_output=True,
                     check=True,
-                    env=dict(GIT_COMMITTER_DATE=DATE, GIT_AUTHOR_DATE=DATE),
+                    env={"GIT_COMMITTER_DATE": date, "GIT_AUTHOR_DATE": date},
                 )
 
             execute("-c", "init.defaultBranch=main", "init")
@@ -206,15 +229,15 @@ class TestMain(unittest.TestCase):
             )
 
     @classmethod
-    def tearDownClass(cls):
+    def tearDownClass(cls) -> None:
         cls._clean()
 
     @classmethod
-    def _clean(cls):
+    def _clean(cls) -> None:
         rmtree(Path(cls.simple_repository).joinpath(".git"), ignore_errors=True)
         rmtree(Path(cls.extension_repository).joinpath(".git"), ignore_errors=True)
 
-    def test_main_twice(self):
+    def test_main_twice(self) -> None:
         with (
             TemporaryDirectory() as output,
             patch("reproducibly.default_subprocess_runner", quiet_subprocess_runner),
@@ -228,12 +251,12 @@ class TestMain(unittest.TestCase):
 
         self.assertEqual(0, result1)
         self.assertEqual(1, len(sdists))
-        self.assertEqual(self.DATE, datetime.fromtimestamp(mtime))
+        self.assertEqual(self.date, datetime.fromtimestamp(mtime, tz=UTC))
         self.assertEqual(0, result2)
         self.assertEqual(1, count)
 
-    def test_main_passes_source_date_epoch(self):
-        mtime = datetime(2001, 1, 1).timestamp()
+    def test_main_passes_source_date_epoch(self) -> None:
+        mtime = datetime(2001, 1, 1, tzinfo=UTC).timestamp()
         with (
             patch("reproducibly._build"),
             patch("reproducibly.cleanse_sdist") as mock,
@@ -243,12 +266,16 @@ class TestMain(unittest.TestCase):
             main([self.simple_repository, output])
         mock.assert_called_once_with(ANY, mtime)
 
-    def test_extension(self):
-        def run_(*args, **kwargs):
-            """Avoid `podman create` output"""
+    def test_extension(self) -> None:
+        def run_(
+            *args: Any,  # noqa: ANN401 type annotations for subprocess.run are complicated
+            **kwargs: Any,  # noqa: ANN401 ”
+        ) -> CompletedProcess[Any]:
+            """Avoid `podman create` output."""
+            del kwargs["check"]
             if args[0][:2] == ["podman", "create"]:
                 kwargs["capture_output"] = True
-            return run(*args, **kwargs)
+            return run(*args, check=True, **kwargs)
 
         # Avoid auditwheel output
         # https://cibuildwheel.readthedocs.io/en/stable/options/#repair-wheel-command
@@ -271,27 +298,32 @@ class TestMain(unittest.TestCase):
 
 
 class TestParseArgs(unittest.TestCase):
-    def test_valid(self):
-        with TemporaryDirectory() as directory, TemporaryDirectory() as output:
-            directory = Path(directory)
+    """Test the parse_args function."""
+
+    def repository(self, directory: Path) -> Path:
+        (repository := directory / "example").mkdir()
+        run(["/usr/bin/git", "init"], check=True, cwd=repository, capture_output=True)
+        return repository
+
+    def test_valid(self) -> None:
+        with TemporaryDirectory() as directory_, TemporaryDirectory() as output:
+            directory = Path(directory_)
             sdist = directory / "example-0.0.1.tar.gz"
             sdist.touch()
-            (repository := directory / "example").mkdir()
-            run(["git", "init"], check=True, cwd=repository, capture_output=True)
+            repository = self.repository(directory)
 
             result = parse_args([str(sdist), str(repository), str(output)])
 
         self.assertEqual(result["sdists"], [sdist])
         self.assertEqual(result["repositories"], [repository])
 
-    def test_valid_creates_output_directory(self):
-        with TemporaryDirectory() as directory, TemporaryDirectory() as parent:
-            directory = Path(directory)
+    def test_valid_creates_output_directory(self) -> None:
+        with TemporaryDirectory() as directory_, TemporaryDirectory() as parent:
+            directory = Path(directory_)
             sdist = directory / "example-0.0.1.tar.gz"
             repository = directory / "example"
             sdist.touch()
-            (repository := directory / "example").mkdir()
-            run(["git", "init"], check=True, cwd=repository, capture_output=True)
+            repository = self.repository(directory)
             output = Path(parent) / "dist"
 
             result = parse_args([str(sdist), str(repository), str(output)])
@@ -299,7 +331,7 @@ class TestParseArgs(unittest.TestCase):
         self.assertEqual(result["sdists"], [sdist])
         self.assertEqual(result["repositories"], [repository])
 
-    def test_invalid_because_empty_directory(self):
+    def test_invalid_because_empty_directory(self) -> None:
         with (
             TemporaryDirectory() as empty,
             TemporaryDirectory() as output,
@@ -310,7 +342,7 @@ class TestParseArgs(unittest.TestCase):
 
         self.assertEqual(cm.exception.code, 2)
 
-    def test_invalid_because_file_not_tar_gz_as_input(self):
+    def test_invalid_because_file_not_tar_gz_as_input(self) -> None:
         with (
             TemporaryDirectory() as parent,
             TemporaryDirectory() as output,
@@ -322,7 +354,7 @@ class TestParseArgs(unittest.TestCase):
 
         self.assertEqual(cm.exception.code, 2)
 
-    def test_invalid_output(self):
+    def test_invalid_output(self) -> None:
         with (
             TemporaryDirectory() as empty,
             NamedTemporaryFile() as output,
@@ -333,7 +365,7 @@ class TestParseArgs(unittest.TestCase):
 
         self.assertEqual(cm.exception.code, 2)
 
-    def test_version(self):
+    def test_version(self) -> None:
         with patch("sys.stdout") as mock, self.assertRaises(SystemExit) as cm:
             parse_args(["--version"])
         mock.write.assert_called_once()
@@ -341,8 +373,10 @@ class TestParseArgs(unittest.TestCase):
 
 
 class SimpleFixtureMixin:
+    """Mixin for working with ./fixtures/."""
+
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
         cls._temp = TemporaryDirectory()
         with DefaultIsolatedEnv() as env:
             builder = ProjectBuilder.from_isolated_env(
@@ -357,98 +391,105 @@ class SimpleFixtureMixin:
         cls._sdist = cls.sdist.read_bytes()
         cls.date = 315532800.0
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.sdist.write_bytes(self._sdist)
 
     @classmethod
-    def tearDownClass(cls):
+    def tearDownClass(cls) -> None:
         cls._temp.cleanup()
 
 
-class TestCleanseMetadata(SimpleFixtureMixin, unittest.TestCase):
+class TestCleanseSdist(SimpleFixtureMixin, unittest.TestCase):
+    """Test the cleanse_sdist function."""
+
     def values(self, attribute: str) -> set[str | int]:
-        """Return a set with all the values of attribute in self.sdist"""
+        """Return a set with all the values of attribute in self.sdist."""
         with tarfile.open(self.sdist) as tar:
             return {getattr(tarinfo, attribute) for tarinfo in tar.getmembers()}
 
-    def test_uids_are_zero_using_fixture(self):
+    def test_uids_are_zero_using_fixture(self) -> None:
         if self.values("uid") == {0}:
-            raise RuntimeError("uids are already {0} before starting")
+            msg = "uids are already {0} before starting"
+            raise RuntimeError(msg)
 
         returncode = cleanse_sdist(self.sdist, self.date)
 
         self.assertEqual(returncode, 0)
         self.assertEqual(self.values("uid"), {0})
 
-    def test_gids_are_zero_using_fixture(self):
+    def test_gids_are_zero_using_fixture(self) -> None:
         if self.values("gid") == {0}:
-            raise RuntimeError("gids are already {0} before starting")
+            msg = "gids are already {0} before starting"
+            raise RuntimeError(msg)
 
         returncode = cleanse_sdist(self.sdist, self.date)
 
         self.assertEqual(returncode, 0)
         self.assertEqual(self.values("gid"), {0})
 
-    def test_unames_are_root_using_fixture(self):
+    def test_unames_are_root_using_fixture(self) -> None:
         if self.values("uname") == {"root"}:
-            raise RuntimeError('unames are already {"root"} before starting')
+            msg = 'unames are already {"root"} before starting'
+            raise RuntimeError(msg)
 
         returncode = cleanse_sdist(self.sdist, self.date)
 
         self.assertEqual(returncode, 0)
         self.assertEqual(self.values("uname"), {"root"})
 
-    def test_gnames_are_root_using_fixture(self):
+    def test_gnames_are_root_using_fixture(self) -> None:
         if self.values("gname") == {"root"}:
-            raise RuntimeError('gnames are already {"root"} before starting')
+            msg = 'gnames are already {"root"} before starting'
+            raise RuntimeError(msg)
 
         returncode = cleanse_sdist(self.sdist, self.date)
 
         self.assertEqual(returncode, 0)
         self.assertEqual(self.values("gname"), {"root"})
 
-    def test_utime_using_fixture(self):
-        def stat(attribute: str):
+    def test_utime_using_fixture(self) -> None:
+        def stat(attribute: Literal["st_mtime", "st_atime"]) -> float:
             return getattr(Path(self.sdist).stat(), attribute)
 
-        expected = datetime(1980, 1, 1, 0, 0, 0).timestamp()
-        if stat("st_mtime") == expected:
-            raise RuntimeError("mtime is already set")
-        if stat("st_atime") == expected:
-            raise RuntimeError("atime is already set")
+        if stat("st_mtime") == EARLIEST:
+            msg = "mtime is already set"
+            raise RuntimeError(msg)
+        if stat("st_atime") == EARLIEST:
+            msg = "atime is already set"
+            raise RuntimeError(msg)
 
-        returncode = cleanse_sdist(self.sdist, expected)
+        returncode = cleanse_sdist(self.sdist, EARLIEST)
 
         self.assertEqual(returncode, 0)
-        self.assertEqual(stat("st_mtime"), expected)
-        self.assertEqual(stat("st_atime"), expected)
+        self.assertEqual(stat("st_mtime"), EARLIEST)
+        self.assertEqual(stat("st_atime"), EARLIEST)
 
-    def test_gzip_mtime_using_fixture(self):
+    def test_gzip_mtime_using_fixture(self) -> None:
         def gzip_mtime() -> int | None:
             with gzip.GzipFile(filename=self.sdist) as file:
                 file.read()
                 return file.mtime
 
-        expected = datetime(1980, 1, 1, 0, 0, 0).timestamp()
-        if gzip_mtime() == expected:
-            raise RuntimeError("mtime is already set")
+        if gzip_mtime() == EARLIEST:
+            msg = "mtime is already set"
+            raise RuntimeError(msg)
 
-        returncode = cleanse_sdist(self.sdist, expected)
-
-        self.assertEqual(returncode, 0)
-        self.assertEqual(gzip_mtime(), expected)
-
-    def test_mtime_using_fixture(self):
-        expected = datetime(1980, 1, 1, 0, 0, 0).timestamp()
-        if self.values("mtime") == {expected}:
-            raise RuntimeError("mtime is already set")
-
-        returncode = cleanse_sdist(self.sdist, expected)
+        returncode = cleanse_sdist(self.sdist, EARLIEST)
 
         self.assertEqual(returncode, 0)
-        self.assertEqual(self.values("mtime"), {expected})
+        self.assertEqual(gzip_mtime(), EARLIEST)
 
-    def test_no_compression(self):
+    def test_mtime_using_fixture(self) -> None:
+        if self.values("mtime") == {EARLIEST}:
+            msg = "mtime is already set"
+            raise RuntimeError(msg)
+
+        returncode = cleanse_sdist(self.sdist, EARLIEST)
+
+        self.assertEqual(returncode, 0)
+        self.assertEqual(self.values("mtime"), {EARLIEST})
+
+    def test_no_compression(self) -> None:
         returncode = cleanse_sdist(self.sdist, self.date)
 
         compressed = self.sdist.stat().st_size

--- a/reproducibly_test.py
+++ b/reproducibly_test.py
@@ -375,6 +375,10 @@ class TestParseArgs(unittest.TestCase):
 class SimpleFixtureMixin:
     """Mixin for working with ./fixtures/."""
 
+    date: float
+    sdist: Path
+    _sdist: bytes
+
     @classmethod
     def setUpClass(cls) -> None:
         cls._temp = TemporaryDirectory()

--- a/reproducibly_test.py
+++ b/reproducibly_test.py
@@ -378,7 +378,7 @@ class SimpleFixtureMixin:
     @classmethod
     def setUpClass(cls) -> None:
         cls._temp = TemporaryDirectory()
-        with DefaultIsolatedEnv() as env:
+        with DefaultIsolatedEnv(installer="uv") as env:
             builder = ProjectBuilder.from_isolated_env(
                 env,
                 source_dir="fixtures/simple",


### PR DESCRIPTION
- **Check .github/ with yamllint**
- **Switch to uv from pipx**
- **Switch from flake8 to ruff**
- **Switch from virtualenv to uv for DefaultIsolatedEnv in tests**
- **Switch to current format for license information**
- **Switch to urlopen for source distributions from pip download**
- **Address mypy warnings in reproducibly_test.py**
- **Expand the scope of usort check**
- **Run mypy on this repository**
- **Run pyright in CI and upgrade automatically**
- **Increment version number → 0.0.16**
